### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md
   + Surya V Duggirala (@suryadu)
   + David Stewart
   + Michael Paulson (@michaelbpaulson)
+  + Gareth Ellis (@gareth-ellis)


### PR DESCRIPTION
Noticed after looking into https://github.com/nodejs/benchmarking/issues/43 that I wasn't on the list in the readme.

I had a look through the previous minutes etc and couldn't see Mark Leitch or David Stewart mentioned with a github id.