### PR TITLE
Adding Docker on AcmeAir to repo.

### DIFF
--- a/experimental/benchmarks/acmeair/Dockerfile
+++ b/experimental/benchmarks/acmeair/Dockerfile
@@ -1,13 +1,11 @@
 FROM ubuntu:14.04
 MAINTAINER Gareth Ellis <gareth.ellis@uk.ibm.com>
-RUN apt-get update && apt-get install git openjdk-7-jdk mongodb zip unzip numactl bc wget -y
-RUN mkdir /node 
-RUN date
+RUN mkdir /node /node/Jmeter /node/node_undertest /node/node_baseline
 WORKDIR /node
-RUN mkdir Jmeter node_undertest node_baseline
-RUN git clone http://github.com/gareth-ellis/benchmarking 
-RUN bash /node/benchmarking/experimental/benchmarks/acmeair/setupJmeter.sh
-RUN numactl --hardware
-COPY node_undertest /node/node_undertest
-COPY node_baseline /node/node_baseline
-RUN /node/benchmarking/experimental/benchmarks/acmeair/run_acmeair_docker.sh
+RUN apt-get update \
+&& apt-get install git openjdk-7-jdk unzip mongodb numactl bc wget -y \
+&& rm -rf /var/lib/apt/lists/* \
+&& git clone http://github.com/gareth-ellis/benchmarking \
+&& bash /node/benchmarking/experimental/benchmarks/acmeair/setupJmeter.sh \
+&& apt-get purge -y --auto-remove git unzip 
+CMD [ "/node/benchmarking/experimental/benchmarks/acmeair/run_acmeair_docker.sh" ]

--- a/experimental/benchmarks/acmeair/Dockerfile
+++ b/experimental/benchmarks/acmeair/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir /node /node/Jmeter /node/node_undertest /node/node_baseline
 WORKDIR /node
 RUN apt-get update \
 && apt-get install git openjdk-7-jdk unzip mongodb numactl bc wget -y \
-&& rm -rf /var/lib/apt/lists/* \
-&& git clone http://github.com/gareth-ellis/benchmarking \
+&& git clone http://github.com/nodejs/benchmarking \
 && bash /node/benchmarking/experimental/benchmarks/acmeair/setupJmeter.sh \
-&& apt-get purge -y --auto-remove git unzip 
+&& apt-get purge -y --auto-remove git unzip \
+&& rm -rf /var/lib/apt/lists/*
 CMD [ "/node/benchmarking/experimental/benchmarks/acmeair/run_acmeair_docker.sh" ]

--- a/experimental/benchmarks/acmeair/Dockerfile
+++ b/experimental/benchmarks/acmeair/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:14.04
+MAINTAINER Gareth Ellis <gareth.ellis@uk.ibm.com>
+RUN apt-get update && apt-get install git openjdk-7-jdk mongodb zip unzip numactl bc wget -y
+RUN mkdir /node 
+RUN date
+WORKDIR /node
+RUN mkdir Jmeter node_undertest node_baseline
+RUN git clone http://github.com/gareth-ellis/benchmarking 
+RUN bash /node/benchmarking/experimental/benchmarks/acmeair/setupJmeter.sh
+RUN numactl --hardware
+COPY node_undertest /node/node_undertest
+COPY node_baseline /node/node_baseline
+RUN /node/benchmarking/experimental/benchmarks/acmeair/run_acmeair_docker.sh

--- a/experimental/benchmarks/acmeair/kill_node_linux
+++ b/experimental/benchmarks/acmeair/kill_node_linux
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo "`date`: Checking for Node processes"
+ps -ef  | grep '/node ' | grep -v 'grep'
+
+NODE_PIDS=`ps -ef | grep '/node ' | grep -v 'grep' | awk '{print $2;}'`
+
+# Try killing them
+if [ -n "$NODE_PIDS" ]; then
+        echo "Killing: $NODE_PIDS"
+        kill $NODE_PIDS
+        echo "Waiting 10s for Node to exit"
+        sleep 10
+fi
+
+# Check to see if all Nodes exited
+NODE_PIDS=`ps -ef  | grep '/node ' | grep -v 'grep' | awk '{print $2;}'`
+
+# If not, try kill -9
+while [ -n "$NODE_PIDS" ]; do
+        echo "Trying kill -9: $NODE_PIDS"
+        kill -9 $NODE_PIDS
+        echo "`date`: Waiting 10s for Node to die"
+        sleep 10
+        NODE_PIDS=`ps -ef | grep '/node ' | grep -v 'grep' | awk '{print $2;}'`
+done
+

--- a/experimental/benchmarks/acmeair/mongodb.sh
+++ b/experimental/benchmarks/acmeair/mongodb.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+echo "Must pass in start, stop or status"
+exit
+fi
+DIR=`dirname $0`
+CURRENT_DIR=`cd $DIR;pwd`
+pushd $CURRENT_DIR
+
+case $1 in 
+start)
+rm -rf database
+mkdir database
+rm mongodb.out
+mongod --dbpath database >> mongodb.out 2>&1 &
+while [ `grep -c "db version " mongodb.out` -lt 1 ]
+do 
+sleep 2
+done
+echo "mongo started at `date`"
+;;
+stop)
+
+mongod --dbpath database  --shutdown
+rm -rf database
+;;
+status)
+ps -ef|grep mongod|grep -v grep
+;;
+esac
+popd

--- a/experimental/benchmarks/acmeair/run_acmeair_docker.sh
+++ b/experimental/benchmarks/acmeair/run_acmeair_docker.sh
@@ -3,6 +3,8 @@ NODE_UNDERTEST=/node/node_undertest/bin
 chmod u+x ${NODE_UNDERTEST}/node
 NODE_BASELINE=/node/node_baseline/bin
 chmod u+x ${NODE_BASELINE}/node
+echo "Machine information:"
+numactl --hardware
 echo "NODE Build :"
 ${NODE_UNDERTEST}/node -v
 ${NODE_UNDERTEST}/node -e "console.log(process.versions)"

--- a/experimental/benchmarks/acmeair/run_acmeair_docker.sh
+++ b/experimental/benchmarks/acmeair/run_acmeair_docker.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+NODE_UNDERTEST=/node/node_undertest/bin
+chmod u+x ${NODE_UNDERTEST}/node
+NODE_BASELINE=/node/node_baseline/bin
+chmod u+x ${NODE_BASELINE}/node
+echo "NODE Build :"
+${NODE_UNDERTEST}/node -v
+${NODE_UNDERTEST}/node -e "console.log(process.versions)"
+echo "Baseline set as :"
+${NODE_BASELINE}/node -v
+${NODE_BASELINE}/node -e "console.log(process.versions)"
+build_fail=0
+baseline_fail=0
+CURRENT_PATH=${PATH}
+echo "using baseline to do npm install."
+pushd /node/acmeair-nodejs
+export PATH=${NODE_BASELINE}:${CURRENT_PATH}
+
+npm install
+popd
+#Driver command for Jmeter
+DRIVERCMD=/node/Jmeter/bin/jmeter
+LOGS="/node/results/`date +%Y%m%d-%H%M%S`/"
+mkdir -p $LOGS
+for i in `seq 1 3`
+do
+
+pushd /node/benchmarking/experimental/benchmarks/acmeair
+echo "Running build:"
+export PATH=${NODE_UNDERTEST}:${CURRENT_PATH}
+./run_acmeair.sh /node >> ${LOGS}/BUILD-${i}.out 2>&1
+throughput_build=`grep "metric throughput" ${LOGS}/BUILD-${i}.out|awk {'print $3'}`
+if [ "${throughput_build%.*}" -ge 0 ]; then
+	echo "Build generated throughput number of ${throughput_build}"
+	build_results="${build_results} ${throughput_build}"
+else
+	let build_fail=$build_fail+1
+	echo "Failed job output:"
+	cat  ${LOGS}/BUILD-${i}.out
+fi
+
+export PATH=${NODE_BASELINE}:${CURRENT_PATH}
+./run_acmeair.sh /node >> ${LOGS}/BASELINE-${i}.out 2>&1
+throughput_baseline=`grep "metric throughput" ${LOGS}/BASELINE-${i}.out|awk {'print $3'}`
+if [ "${throughput_baseline%.*}" -ge 0 ]; then
+	echo "Baseline generated throughput number of ${throughput_baseline}"
+	baseline_results="${baseline_results} ${throughput_baseline}"
+else
+	let baseline_fail=$baseline_fail+1
+	echo "Failed job output:"
+	cat ${LOGS}/BASELINE-${i}.out
+fi
+
+popd
+done
+total=0
+count=0
+for result in $build_results
+do
+total=`echo $total+$result|bc`
+let count=count+1
+done
+build_average=`echo "$total/$count"|bc`
+total=0
+count=0
+for result in $baseline_results
+do
+total=`echo $total+$result|bc`
+let count=count+1
+done
+baseline_average=`echo "$total/$count"|bc`
+
+#work out percenntage - throughput = higher is better
+
+percentage=`echo "scale=4;($build_average/$baseline_average)*100"|bc`
+echo "RESULTS:"
+echo "BUILD results:"
+echo ${build_results}
+echo "Average : ${build_average}"
+echo "BASELINE results:"
+echo ${baseline_results}
+echo "Average: ${baseline_average}"
+echo "Percentage of build vs baseline - above 100% is good, less than is bad"
+echo "Percentage : ${percentage}%"
+

--- a/experimental/benchmarks/acmeair/setupJmeter.sh
+++ b/experimental/benchmarks/acmeair/setupJmeter.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+JMETER_VERSION=apache-jmeter-3.0
+DIR=`dirname $0`
+CURRENT_DIR=`cd $DIR;pwd`
+
+mkdir /node/Jmeter_setup
+pushd /node/Jmeter_setup
+wget https://archive.apache.org/dist/jmeter/binaries/${JMETER_VERSION}.zip
+unzip ${JMETER_VERSION}.zip
+git clone https://github.com/acmeair/acmeair-driver
+pushd acmeair-driver
+	git checkout f4ee2b451cc381b7539601d1b741d8b01684fe2b
+popd
+
+wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/json-simple/json-simple-1.1.1.jar
+pushd /node/Jmeter_setup/acmeair-driver
+	./gradlew build
+	cp acmeair-jmeter/build/libs/acmeair-jmeter-*-SNAPSHOT.jar  /node/Jmeter_setup/${JMETER_VERSION}/lib/ext/
+popd
+cp json-simple-1.1.1.jar /node/Jmeter_setup/${JMETER_VERSION}/lib/ext/
+git clone https://github.com/acmeair/acmeair-nodejs
+pushd acmeair-nodejs
+git checkout 009bd063700089a2680b696336d87bd97e412f0e
+sed -i 's/9080/4000/g' settings.json
+
+popd
+
+mv acmeair-nodejs ../
+mv ${JMETER_VERSION}/*  ../Jmeter
+popd
+mkdir /node/mongo3
+cp ${CURRENT_DIR}/mongodb.sh /node/mongo3/
+


### PR DESCRIPTION
This is the work for running AcmeAIr on docker as requested in #47 

You need the Dockerfile, plus two folders - each containing copies of node.

node_undertest/bin/node -> this is the copy of node you're wanting to test
node_baseline/bin/node -> this is the copy of node you're using as a baseline - typically this will be the same as node_undertest but without a change that's potentially risky to performance.

I've tested it locally and the I'm getting fairly consistent numbers. By default it will run three iterations of copy of node interleaved, and then report a percentage at the end of the test along with the individual scores.

A percentage above 100% is good, below 100% is bad.

e.g.

`docker build -t gareth/acmeair:test .`

we then get 
RESULTS:
BUILD results:
2144.56 2139.11 2136.03
Average : 2139
BASELINE results:
1871.63 1914.1 1900.93
Average: 1895
Percentage of build vs baseline - above 100% is good, less than is bad
Percentage : 112.8700%

I'll leave this for a day or so and then merge it in - i haven't changed any other files, so it won't effect the current acmeair tests.
