### PR TITLE
Fix startup memory benchmark failures

### DIFF
--- a/benchmarks/startup_footprint/report-startup-memory.js
+++ b/benchmarks/startup_footprint/report-startup-memory.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log(process.memoryUsage().rss);


### PR DESCRIPTION
Recent commit in node repo removed one of the files
required for the startup memory test as it was not
used in the bundled benchmark suite.  Add it back
to the benchmarking repo instead.

Fixes: https://github.com/nodejs/benchmarking/issues/53