### PR TITLE
doc: add initial table for coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ Its responsibilities are:
 4. Track/publicize performance between builds/releases
 
 
-AcmeAir is proposed as one of the benchmark to consider: https://github.com/acmeair/acmeair-nodejs
+The path forward is to:
+ * Define the important
+   [use cases](https://github.com/nodejs/benchmarking/blob/master/docs/use_cases.md)
+ * Define the key
+   [runtime attributes](https://github.com/nodejs/benchmarking/blob/master/docs/runtime_attributes.md)
+ * Find/create benchmarks that provide good coverage for the
+   use cases and attributes
+   ([current table](https://github.com/nodejs/benchmarking/blob/master/docs/use_cases.md))
 
 See here for information about the instructure in place so far:
 https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md

--- a/docs/case_coverage.md
+++ b/docs/case_coverage.md
@@ -12,7 +12,7 @@ Use case                                   |Benchmark with coverage| Notes
 Service oriented architectures (SOA) | |
 Microservice-based applications | |
 Generating/serving dynamic web page content | Acme Air Ops/s <BR>Acme Air Latency |
-SPA applications with bidirectional communication over WebSockets and/or HTTP/2 | |
+Single page applications with bidirectional communication over WebSockets and/or HTTP/2 | |
 Agents and Data Collectors | |
 Small scripts | Require New Ops<BR> Require Cached Ops | Needs more attributes tested
 startup/stop time | Start + stop Time |

--- a/docs/case_coverage.md
+++ b/docs/case_coverage.md
@@ -1,0 +1,31 @@
+# Coverage of use cases and key attributes
+
+Coverage of each of the uses cases and key atributes
+defined in:
+ * [use cases](https://github.com/nodejs/benchmarking/blob/master/docs/use_cases.md)
+ * [key attributes](https://github.com/nodejs/benchmarking/blob/master/docs/runtime_attributes.md)
+
+# Use Cases
+
+Use case                                   |Benchmark with coverage| Notes
+-------------------------------------------|-----------------------|-------
+Service oriented architectures (SOA) | |
+Microservice-based applications | |
+Generating/serving dynamic web page content | Acme Air Ops/s <BR>Acme Air Latency |
+SPA applications with bidirectional communication over WebSockets and/or HTTP/2 | |
+Agents and Data Collectors | |
+Small scripts | Require New Ops<BR> Require Cached Ops | Needs more attributes tested
+startup/stop time | Start + stop Time |
+
+# Key Attributes
+Key attribute                              |Benchmark with coverage| Notes
+-------------------------------------------|-----------------------|-------
+memmory footprint at startup | Startup footprint |
+memory footprint after load metrics are collected (timing will depend on the specific benchmark) | Acme Air footprint after load | 
+Node.js process cpu usage when idle | |
+max throughput as measured through<BR> max http requests served/s | Acme Air Ops/sec |
+gc cpu use under load | |
+gc allocation throughput under load | |
+gc max pause times under load | |
+install package size | |
+size on disk once installed | |


### PR DESCRIPTION
Add table that shows which of the benchmarks
run nightly cover the user cases or key attributes