### PR TITLE
add coverage to 7.x in benchmarking chart generation

### DIFF
--- a/benchmarks/acmeair_latency/acmeairLatency.json
+++ b/benchmarks/acmeair_latency/acmeairLatency.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_latency/acmeairLatency.json
+++ b/benchmarks/acmeair_latency/acmeairLatency.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_postfootprint/acmeairPostfootprint.json
+++ b/benchmarks/acmeair_postfootprint/acmeairPostfootprint.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_postfootprint/acmeairPostfootprint.json
+++ b/benchmarks/acmeair_postfootprint/acmeairPostfootprint.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_prefootprint/acmeairPrefootprint.json
+++ b/benchmarks/acmeair_prefootprint/acmeairPrefootprint.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_prefootprint/acmeairPrefootprint.json
+++ b/benchmarks/acmeair_prefootprint/acmeairPrefootprint.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_throughput/acmeairThroughput.json
+++ b/benchmarks/acmeair_throughput/acmeairThroughput.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/acmeair_throughput/acmeairThroughput.json
+++ b/benchmarks/acmeair_throughput/acmeairThroughput.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/require_cached/requireCached.json
+++ b/benchmarks/require_cached/requireCached.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/require_cached/requireCached.json
+++ b/benchmarks/require_cached/requireCached.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/require_new/requireNew.json
+++ b/benchmarks/require_new/requireNew.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/require_new/requireNew.json
+++ b/benchmarks/require_new/requireNew.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/start_stop_time/startupChart.json
+++ b/benchmarks/start_stop_time/startupChart.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/start_stop_time/startupChart.json
+++ b/benchmarks/start_stop_time/startupChart.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }

--- a/benchmarks/startup_footprint/footprintChart.json
+++ b/benchmarks/startup_footprint/footprintChart.json
@@ -8,7 +8,7 @@
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
-              {"streamid": 5, "name": "7.x", "color": "yellow" }
+              {"streamid": 5, "name": "7.x", "color": "grey" }
             ],
  "enabled": true
 }

--- a/benchmarks/startup_footprint/footprintChart.json
+++ b/benchmarks/startup_footprint/footprintChart.json
@@ -7,7 +7,8 @@
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 3, "name": "0.12.x", "color": "green" },
-              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" }
+              {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
+              {"streamid": 5, "name": "7.x", "color": "yellow" }
             ],
  "enabled": true
 }


### PR DESCRIPTION
Add coverage for v7.x to the results on benchmarking.nodejs.org

Fixes: https://github.com/nodejs/benchmarking/issues/65