### PR TITLE
acmeair: add awk script to calculate latency.

### DIFF
--- a/experimental/benchmarks/acmeair/acmeair_latency.awk
+++ b/experimental/benchmarks/acmeair/acmeair_latency.awk
@@ -1,0 +1,26 @@
+BEGIN {
+    IGNORECASE=1;
+    FS = ",";
+    count = 0;
+}
+
+
+NR == 1 {
+    for (i = 1; i <= NF; i++) {
+        if ($i == "Latency") {
+            cidx = i;
+        }
+    }
+}
+
+
+NR > 1 {
+    if (cidx > 0) {
+        count++;
+        sum += $cidx;
+        }
+    }
+    
+END { 
+    print sum/count; 
+    }

--- a/experimental/benchmarks/acmeair/run_acmeair.sh
+++ b/experimental/benchmarks/acmeair/run_acmeair.sh
@@ -287,7 +287,7 @@ done
 # print output
 echo -e "\n##BEGIN $TEST_NAME OUTPUT $(date)\n" 2>&1 | tee -a $SUMFILE
 echo metric throughput $(cat $JMETER_LOGFILE | awk -f ${SCRIPT_DIR}/acmeair_score.awk) 2>&1 | tee -a $SUMFILE
-echo metric latency $(cat $JMETER_LOGFILE | sed 's/ //g' | sed 's/,/ /g' | awk 'BEGIN { COUNT=0; SUM=0 } { SUM=SUM+$10; COUNT=COUNT+1 } END { print SUM/COUNT }') 2>&1 | tee -a $SUMFILE
+echo metric latency $(cat $JMETER_LOGFILE | awk -f ${SCRIPT_DIR}/acmeair_latency.awk) 2>&1 | tee -a $SUMFILE
 mv $JMETER_LOGFILE $LOGDIR_TEMP/$LOGDIR_PREFIX
 export OUT_LIST="$OUT_LIST $LOGDIR_PREFIX/jmeter.log"
 echo "metric pre footprint $pre"


### PR DESCRIPTION
To make the calculation of the latency more robust,
the added awk script looks for the position of "Latency"
in the heading. Choosing "," as field seperator we
find the latency at the determined position.