### PR TITLE
doc: update membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md
 ## Current Project Team Members
   + Michael Dawson (@mhdawson) Facilitaor 
   + Trevor Norris (@trevnorris)
-  + Yang Lei (@yanglei99)
   + Ali Sheikh (@ofrobots)
-  + Chris Bailey (@seabaylea)
   + Yosuke Furukawa (@yosuke-furukawa)
   + Yunong Xiao (@yunong)
   + Mark Leitch (@m-leitch)


### PR DESCRIPTION
Updating membership based on feedback so far
on https://github.com/nodejs/benchmarking/issues/70
as well as individual conversations.