### PR TITLE
Show latest results as numbers in the chartGen

### DIFF
--- a/tools/chartGen/createpage.js
+++ b/tools/chartGen/createpage.js
@@ -50,7 +50,8 @@ var generatePage = function(benchConfigFile, nowDone) {
                       item.color + '",\n    data: data' + item.streamid + '\n  }\n' );
         datasetList.push('dataset' + item.streamid);
         legend.push('    <tr><td><font color="' + item.color + '">' + chartConfig.name +
-                    '(' + item.name + ')</font></td></tr>\n');
+                    '(' + item.name + ')</td><td>&nbsp;</td><td><font color="' + item.color +
+                    '">Latest result: ' + rows[rows.length-1].value + '</font></td></tr>\n');
         dataElements.push(createData(item.streamid, rows));
         callbackDone();
       });


### PR DESCRIPTION
This PR relates to issue #87, adding the numerical result of the latest benchmarking run to the legend of the chart, which then will look similar to this -

```
acmeair Ops/s[higher is better](master)	 Latest result: 2301
acmeair Ops/s[higher is better](4.x)	 Latest result: 1858
acmeair Ops/s[higher is better](0.12.x)	 Latest result: 1638
acmeair Ops/s[higher is better](6.x)	 Latest result: 2092
acmeair Ops/s[higher is better](7.x)	 Latest result: 2300
```

Have run through all the results - it seems to make the PNG files easier to read given the amount of overlaying of graph points that can exist.