### PR TITLE
src: drop 0.12.x from the benchmark results

### DIFF
--- a/benchmarks/acmeair_latency/acmeairLatency.json
+++ b/benchmarks/acmeair_latency/acmeairLatency.json
@@ -6,7 +6,6 @@
  "outputBase" : "acmeair_latency",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/acmeair_postfootprint/acmeairPostfootprint.json
+++ b/benchmarks/acmeair_postfootprint/acmeairPostfootprint.json
@@ -6,7 +6,6 @@
  "outputBase" : "acmeair_postfootprint",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/acmeair_prefootprint/acmeairPrefootprint.json
+++ b/benchmarks/acmeair_prefootprint/acmeairPrefootprint.json
@@ -6,7 +6,6 @@
  "outputBase" : "acmeair_prefootprint",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/acmeair_throughput/acmeairThroughput.json
+++ b/benchmarks/acmeair_throughput/acmeairThroughput.json
@@ -6,7 +6,6 @@
  "outputBase" : "acmeair_throughput",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/octane/octane.json
+++ b/benchmarks/octane/octane.json
@@ -6,7 +6,6 @@
  "outputBase" : "octane",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/require_cached/requireCached.json
+++ b/benchmarks/require_cached/requireCached.json
@@ -6,7 +6,6 @@
  "outputBase" : "require_cached",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/require_new/requireNew.json
+++ b/benchmarks/require_new/requireNew.json
@@ -6,7 +6,6 @@
  "outputBase" : "require_new",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/start_stop_time/startupChart.json
+++ b/benchmarks/start_stop_time/startupChart.json
@@ -6,7 +6,6 @@
  "outputBase" : "start_stop",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],

--- a/benchmarks/startup_footprint/footprintChart.json
+++ b/benchmarks/startup_footprint/footprintChart.json
@@ -6,7 +6,6 @@
  "outputBase" : "startup_footprint",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
-              {"streamid": 3, "name": "0.12.x", "color": "green" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
               {"streamid": 5, "name": "7.x", "color": "grey" }
             ],


### PR DESCRIPTION
Now that 0.12.x is out of service drop it out of the charts being generated.