### PR TITLE
doc: add Wayne Andrews as collaborator

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md
   + David Stewart(@davidcstewart)
   + Michael Paulson (@michaelbpaulson)
   + Gareth Ellis (@gareth-ellis)
+  + Wayne Andrews (@CurryKitten)


### PR DESCRIPTION
Wayne has being actively working to fix/resolves issues in the
existing benchmarking infrastructure:

https://github.com/nodejs/benchmarking/pull/95
https://github.com/nodejs/benchmarking/pull/85
https://github.com/nodejs/benchmarking/pull/83

I think its time to add him to the collaborator list for the benchmarking WG so
that he can review/land changes as he continues this work.

