### PR TITLE
doc: update to use shared coc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,18 +26,8 @@ By making a contribution to this project, I certify that:
       this project or the open source license(s) involved.
 
 
-
 Code of Conduct
 
-This Code of Conduct is adapted from Rust's wonderful CoC.
-
-    We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
-    Please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
-    Please be kind and courteous. There's no need to be mean or rude.
-    Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
-    Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
-    We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behaviour. We interpret the term "harassment" as including the definition in the Citizen Code of Conduct; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
-    Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the TC members immediately with a capture (log, photo, email) of the harassment if possible. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
-    Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
-    Avoid the use of personal pronouns in code comments or documentation. There is no need to address persons when explaining code (e.g. "When the developer")
+This Working Group uses the common Node.js code of conduct defined
+here: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md.
 


### PR DESCRIPTION
Update to use shared code of conduct.  See
https://github.com/nodejs/TSC/issues/224 for background
discussion.

The benchmarking WG CoC was an exact copy anyway.