### PR TITLE
docs: add Web Developer Tooling use case

### DIFF
--- a/docs/case_coverage.md
+++ b/docs/case_coverage.md
@@ -14,7 +14,7 @@ Microservice-based applications | |
 Generating/serving dynamic web page content | Acme Air Ops/s <BR>Acme Air Latency |
 Single page applications with bidirectional communication over WebSockets and/or HTTP/2 | |
 Agents and Data Collectors | |
-Web Developer Tooling | |
+Web Developer Tooling | [Web Tooling Benchmark](https://github.com/bmeurer/WebToolingBenchmark) |
 Small scripts | Require New Ops<BR> Require Cached Ops | Needs more attributes tested
 startup/stop time | Start + stop Time |
 

--- a/docs/case_coverage.md
+++ b/docs/case_coverage.md
@@ -14,6 +14,7 @@ Microservice-based applications | |
 Generating/serving dynamic web page content | Acme Air Ops/s <BR>Acme Air Latency |
 Single page applications with bidirectional communication over WebSockets and/or HTTP/2 | |
 Agents and Data Collectors | |
+Web Developer Tooling | |
 Small scripts | Require New Ops<BR> Require Cached Ops | Needs more attributes tested
 startup/stop time | Start + stop Time |
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -81,9 +81,9 @@ remotely is often a key requirement.
 Node.js is extensively used in all kinds of tools commonly used
 to build modern web pages, including but not limited to projects like
 [TypeScript](https://www.typescriptlang.org/), [webpack](http://webpack.js.org),
-[Babel](http://babeljs.io), [ESLint](http://eslint.org),
-[Mocha](https://mochajs.org). All these tools are built on top of Node.js and
-are crucial for the success of the modern web platform.
+[Babel](http://babeljs.io), [ESLint](http://eslint.org), and the
+[Chai Assertion Library](http://chaijs.com). All these tools are built on top
+of Node.js and are crucial for the success of the modern web platform.
 
 ## Small scripts
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -14,6 +14,7 @@ The following categories have been identifed:
 * Generating/serving dynamic web page content
 * SPA applications with bidirectional communication over WebSockets and/or HTTP/2
 * Agents and Data Collectors
+* Web Developer Tooling
 * Small scripts
 
 For these use cases one or more of the following are often imporant:
@@ -74,6 +75,15 @@ Application running on a system in order monitor and or manage
 the system or the applications running in it as directed by
 an external monitoring/management system.  The ability to be updated
 remotely is often a key requirement.
+
+## Web Developer Tooling
+
+Node.js is extensively used in all kinds of tools commonly used
+to build modern web pages, including but not limited to projects like
+[TypeScript](https://www.typescriptlang.org/), [webpack](http://webpack.js.org),
+[Babel](http://babeljs.io), and [ESLint](http://eslint.org). All
+these tools are built on top of Node.js and are crucial for the
+success of the modern web platform.
 
 ## Small scripts
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -81,9 +81,9 @@ remotely is often a key requirement.
 Node.js is extensively used in all kinds of tools commonly used
 to build modern web pages, including but not limited to projects like
 [TypeScript](https://www.typescriptlang.org/), [webpack](http://webpack.js.org),
-[Babel](http://babeljs.io), and [ESLint](http://eslint.org). All
-these tools are built on top of Node.js and are crucial for the
-success of the modern web platform.
+[Babel](http://babeljs.io), [ESLint](http://eslint.org),
+[Mocha](https://mochajs.org). All these tools are built on top of Node.js and
+are crucial for the success of the modern web platform.
 
 ## Small scripts
 


### PR DESCRIPTION
This was identified as missing in the last WG meeting, and it's planned
to be addressed by the upcoming WebToolingBenchmark later this year
(see #138).