### PR TITLE
src: give phatom more time to render

### DIFF
--- a/tools/chartGen/createpng.js
+++ b/tools/chartGen/createpng.js
@@ -8,7 +8,7 @@ page.open('file://' + system.args[1], function(status) {
     setTimeout(function() {
       page.render(system.args[2])
       phantom.exit();
-    }, 1000);
+    }, 3000);
   }
 });
 


### PR DESCRIPTION
Latest values were not been displayed properly
as Phantomjs as the page was not fully rendered
by the time Phantomjs generated the picture. Give
Phantomjs more time