### PR TITLE
src: fixup dceis chart templates

### DIFF
--- a/benchmarks/dc_eis_latency/dceisLatency.json
+++ b/benchmarks/dc_eis_latency/dceisLatency.json
@@ -3,7 +3,7 @@
  "name": "node-dc-eis Latency[lower is better]" ,
  "template": "../common/common_template1.html.base",
  "units": "ms",
- "outputBase" : "acmeair_latency",
+ "outputBase" : "dceis_latency",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },

--- a/benchmarks/dc_eis_throughput/dceisThroughput.json
+++ b/benchmarks/dc_eis_throughput/dceisThroughput.json
@@ -3,7 +3,7 @@
  "name": "node-dc-eis Ops/s[higher is better]" ,
  "template": "../common/common_template1.html.base",
  "units": "ops/s",
- "outputBase" : "acmeair_throughput",
+ "outputBase" : "dceis_throughput",
  "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
               {"streamid": 2, "name": "4.x", "color": "red" },
               {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },


### PR DESCRIPTION
They were using the same base names as the acemair
ones and getting overwritten