### PR TITLE
src: add dc-eis charts to main benchmarking page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -86,6 +86,8 @@
                 <li><a href="charts/acmeair_prefootprint.png"><img alt="" src="charts/acmeair_prefootprint.png"/></a></li>
                 <li><a href="charts/acmeair_postfootprint.png"><img alt="" src="charts/acmeair_postfootprint.png"/></a></li>
                 <li><a href="charts/octane.png"><img alt="" src="charts/octane.png"/></a></li>
+                <li><a href="charts/dceis_throughput.png"><img alt="" src="charts/dceis_throughput.png"/></a></li>
+                <li><a href="charts/dceis_latency.png"><img alt="" src="charts/dceis_latency.png"/></a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
I suggest we wait a few days before landing this to make sure they look relatively stable.

Until then you should be able to see the charts at:

https://benchmarking.nodejs.org/charts/dceis_throughput.png
https://benchmarking.nodejs.org/charts/dceis_latency.png

They are not there yet but should show up at next transfer from the benchmarking data machine to benchmarking.nodejs.org.