### PR TITLE
Add files for Web Tooling Benchmark

### DIFF
--- a/benchmarks/web_tooling_benchmark/webToolingBenchmark.json
+++ b/benchmarks/web_tooling_benchmark/webToolingBenchmark.json
@@ -2,10 +2,9 @@
     "benchid": 12,
     "name": "Web Tooling Benchmark Geomean [higher is better]" ,
     "template": "../common/common_template1.html.base",
-    "units": "Geomean of runs/s",
+    "units": "Geomean of runs per 100s",
     "outputBase" : "web_tooling_benchmark",
     "streams": [ {"streamid": 1, "name": "master", "color": "blue" },
-                 {"streamid": 2, "name": "4.x", "color": "red" },
                  {"streamid": 4, "name": "6.x", "color": "DarkMagenta" },
                  {"streamid": 6, "name": "8.x", "color": "grey" }
                ],


### PR DESCRIPTION
This adds the files necessary to add the new [Web Tooling Benchmark](https://github.com/v8/web-tooling-benchmark) to the node benchmarks. I hope I found all the places that need editing in this repo.
I think it should be possible to checkout and build it directly from the Github repository. This should be possible from the shell scripts.