### PR TITLE
Show pre and post memory footprint graphs for dc-eis workload

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -88,6 +88,9 @@
                 <li><a href="charts/octane.png"><img alt="" src="charts/octane.png"/></a></li>
                 <li><a href="charts/dceis_throughput.png"><img alt="" src="charts/dceis_throughput.png"/></a></li>
                 <li><a href="charts/dceis_latency.png"><img alt="" src="charts/dceis_latency.png"/></a></li>
+                <li><a href="charts/dceis_prefootprint.png"><img alt="" src="charts/dceis_prefootprint.png"/></a></li>
+                <li><a href="charts/dceis_postfootprint.png"><img alt="" src="charts/dceis_postfootprint.png"/></a></li>
+
                 <li><a href="charts/web_tooling_benchmark.png"><img alt="" src="charts/web_tooling_benchmark.png"/></a></li>
             </ul>
         </div>


### PR DESCRIPTION
Added two html links which shows pre-run and post-run memory footprint graphs for node-dc-eis workload.