### PR TITLE
doc: add logistics info

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Its responsibilities are:
 3. Add regular execution of chosen benchmarks to Node builds
 4. Track/publicize performance between builds/releases
 
-
 The path forward is to:
  * Define the important
    [use cases](https://github.com/nodejs/benchmarking/blob/master/docs/use_cases.md)
@@ -26,6 +25,18 @@ The path forward is to:
 
 See here for information about the infrastructure in place so far:
 https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md
+
+## Logistics
+
+### Semi-monthly Meetings
+
+Meetings of the working group typically occur every third Tuesday.
+A few days before each meeting, an [issue](https://github.com/nodejs/benchmarking/issues) will be created with the date and time of the meeting.
+The issue will provide schedule logistics as well as
+an agenda,
+links to meeting minutes,
+and
+information about how to join as a participant or a viewer.
 
 ## Current Project Team Members
   + Michael Dawson (@mhdawson) Facilitaor 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md
 
 ### Semi-monthly Meetings
 
-Meetings of the working group typically occur every third Tuesday.
+Meetings of the working group typically occur every third Tuesday as shown on the
+the node.js project [calendar](https://nodejs.org/calendar).
 A few days before each meeting, an [issue](https://github.com/nodejs/benchmarking/issues)
 will be created with the date and time of the meeting.
 The issue will provide schedule logistics as well as

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ https://github.com/nodejs/benchmarking/blob/master/benchmarks/README.md
 ### Semi-monthly Meetings
 
 Meetings of the working group typically occur every third Tuesday.
-A few days before each meeting, an [issue](https://github.com/nodejs/benchmarking/issues) will be created with the date and time of the meeting.
+A few days before each meeting, an [issue](https://github.com/nodejs/benchmarking/issues)
+will be created with the date and time of the meeting.
 The issue will provide schedule logistics as well as
-an agenda,
-links to meeting minutes,
-and
+an agenda, links to meeting minutes, and
 information about how to join as a participant or a viewer.
 
 ## Current Project Team Members


### PR DESCRIPTION
Fixes: #249 

Does anyone have a link to the Node.js calendar (where the meeting dates are listed)? I have a lot of trouble finding it.